### PR TITLE
ci: [KP-2848] Fix golangci-linter error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
   autoupdate_commit_msg: "chore(pre-commit): autoupdate hooks"
 repos:
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.5
+    rev: v1.5.6
     hooks:
       - id: remove-crlf
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -26,12 +26,12 @@ repos:
         args: [ --markdown-linebreak-ext=md ]
       - id: requirements-txt-fixer
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.4.0  # Use the latest version
+    rev: v2.10.1  # Use the latest version
     hooks:
       - id: golangci-lint
         additional_dependencies: []
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.2.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [ commit-msg ]

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 golang        1.25.2
-golangci-lint 2.5.0
+golangci-lint 2.10.1
 goreleaser    2.12.7
 pre-commit    4.3.0
 

--- a/internal/apiclient/api_client.go
+++ b/internal/apiclient/api_client.go
@@ -319,24 +319,24 @@ func NewAPIClient(opt *ApiClientOpt) (*APIClient, error) {
 // This is useful for debugging.
 func (client *APIClient) toString() string {
 	var buffer bytes.Buffer
-	buffer.WriteString(fmt.Sprintf("uri: %s\n", client.Uri))
+	fmt.Fprintf(&buffer, "uri: %s\n", client.Uri)
 	if client.Jwt != nil {
-		buffer.WriteString(fmt.Sprintf("jwt_hashed_token.secret: %s\n", client.Jwt.Secret))
-		buffer.WriteString(fmt.Sprintf("jwt_hashed_token.algorithm: %s\n", client.Jwt.Algortithm))
-		buffer.WriteString(fmt.Sprintf("jwt_hashed_token.claimsJson: %s\n", client.Jwt.Claims))
+		fmt.Fprintf(&buffer, "jwt_hashed_token.secret: %s\n", client.Jwt.Secret)
+		fmt.Fprintf(&buffer, "jwt_hashed_token.algorithm: %s\n", client.Jwt.Algortithm)
+		fmt.Fprintf(&buffer, "jwt_hashed_token.claimsJson: %s\n", client.Jwt.Claims)
 	}
-	buffer.WriteString(fmt.Sprintf("insecure: %t\n", client.Insecure))
-	buffer.WriteString(fmt.Sprintf("username: %s\n", client.Username))
-	buffer.WriteString(fmt.Sprintf("password: %s\n", client.Password))
-	buffer.WriteString(fmt.Sprintf("id_attribute: %s\n", client.IdAttribute))
-	buffer.WriteString(fmt.Sprintf("write_returns_object: %t\n", client.WriteReturnsObject))
-	buffer.WriteString(fmt.Sprintf("create_returns_object: %t\n", client.CreateReturnsObject))
+	fmt.Fprintf(&buffer, "insecure: %t\n", client.Insecure)
+	fmt.Fprintf(&buffer, "username: %s\n", client.Username)
+	fmt.Fprintf(&buffer, "password: %s\n", client.Password)
+	fmt.Fprintf(&buffer, "id_attribute: %s\n", client.IdAttribute)
+	fmt.Fprintf(&buffer, "write_returns_object: %t\n", client.WriteReturnsObject)
+	fmt.Fprintf(&buffer, "create_returns_object: %t\n", client.CreateReturnsObject)
 	buffer.WriteString("headers:\n")
 	for k, v := range client.Headers {
-		buffer.WriteString(fmt.Sprintf("  %s: %s\n", k, v))
+		fmt.Fprintf(&buffer, "  %s: %s\n", k, v)
 	}
 	for _, n := range client.CopyKeys {
-		buffer.WriteString(fmt.Sprintf("  %s", n))
+		fmt.Fprintf(&buffer, "  %s", n)
 	}
 	return buffer.String()
 }


### PR DESCRIPTION
Fix the golangci-lint errors on the main branch.
New rules appeared with the version 2.10.

+ update the pre-commit repos versions

Close KP-2848